### PR TITLE
Startup script args

### DIFF
--- a/warehouse-upload-to-storage-bucket.sh
+++ b/warehouse-upload-to-storage-bucket.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+PATH_TO_IDENTITY_KEYPAIR=$1
+
 set -x
 set -e
 shopt -s nullglob
@@ -25,7 +27,7 @@ if [[ -z $STORAGE_BUCKET ]]; then
   exit 1
 fi
 
-identity_keypair=<path_to_your_identity_keypair>
+identity_keypair=$PATH_TO_IDENTITY_KEYPAIR
 identity_pubkey=$(solana-keygen pubkey "$identity_keypair")
 
 datapoint_error() {

--- a/warehouse.sh
+++ b/warehouse.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-PATH_TO_IDENTITY_KEY=$1
-PATH_TO_LEDGER_SNAPSHOTS=$2
+PATH_TO_LEDGER_DIR=$1
+PATH_TO_LEDGER_SNAPSHOT_DIR=$2
 PATH_TO_IDENTITY_KEYPAIR=$3
 PATH_TO_LOGS=$4
 
-ledger_dir=$PATH_TO_IDENTITY_KEY
-ledger_snapshots_dir=$PATH_TO_LEDGER_SNAPSHOTS
+ledger_dir=$PATH_TO_LEDGER_DIR
+ledger_snapshots_dir=$PATH_TO_LEDGER_SNAPSHOT_DIR
 
 # |touch ~/warehouse-exit-signal| will trigger a clean shutdown
 exit_signal_file=~/warehouse-exit-signal

--- a/warehouse.sh
+++ b/warehouse.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
-ledger_dir=<path_to_your_ledger>
-ledger_snapshots_dir=<path_to_your_ledger_snapshots>
+PATH_TO_IDENTITY_KEY=$1
+PATH_TO_LEDGER_SNAPSHOTS=$2
+PATH_TO_IDENTITY_KEYPAIR=$3
+PATH_TO_LOGS=$4
+
+ledger_dir=$PATH_TO_IDENTITY_KEY
+ledger_snapshots_dir=$PATH_TO_LEDGER_SNAPSHOTS
 
 # |touch ~/warehouse-exit-signal| will trigger a clean shutdown
 exit_signal_file=~/warehouse-exit-signal
@@ -68,7 +73,7 @@ if [[ -f $exit_signal_file ]]; then
   exit 0
 fi
 
-identity_keypair=<path_to_your_identity_keypair>
+identity_keypair=$PATH_TO_IDENTITY_KEYPAIR
 identity_pubkey=$(solana-keygen pubkey "$identity_keypair")
 
 datapoint_error() {
@@ -105,7 +110,7 @@ args=(
   --private-rpc
   --identity "$identity_keypair"
   --ledger "$ledger_dir"
-  --log <path_to_your_logs>
+  --log $PATH_TO_LOGS
   --no-voting
   --skip-poh-verify
   --enable-rpc-transaction-history


### PR DESCRIPTION
This PR aims to make the startup bash scripts easier to use. Rather than manually replacing placeholder values in the scripts it will now take in the command args.

Example:
`warehouse-upload-to-storage-bucket.sh /path/to/identity/key.json`
`warehouse /path/to/ledger/dir /path/to/snapshot/dir /path/to/identity/key.json /path/to/logs`