### PR TITLE
Add entries table to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ In order to import Solana's Bigtable Instance, you'll first need to set own Bigt
 | Table ID   | Column Family Name |
 | :--------- | :----------------: |
 | blocks     | x                  |
+| entries    | x                  |
 | tx         | x                  |
 | tx-by-addr | x                  |
+
+**NOTE:** the `entries` table is new and will be populated as of solana CLI tools v1.18.0
 
 6. It's very important to give the same `Table ID` and `Column Family Name` inside your Bigtable instance or the Dataflow job will fail.
 


### PR DESCRIPTION
As of solana v1.18.0 the BigtableUploadService and `solana-ledger-tool upload` will try to populate the entries table.
Include the new table in the readme.

I didn't see any scripts that needed to be updated, since we instruct users to configure their own bigtables, but please double check I didn't miss anything.